### PR TITLE
Accept apiKey in constructor.

### DIFF
--- a/src/main/java/io/honeybadger/reporter/HoneybadgerReporter.java
+++ b/src/main/java/io/honeybadger/reporter/HoneybadgerReporter.java
@@ -36,8 +36,15 @@ public class HoneybadgerReporter implements NoticeReporter {
     private final Set<String> excludedExceptionClasses;
     private final Gson gson = new GsonBuilder()
             .create();
+    private final String apiKey;
 
     public HoneybadgerReporter() {
+        // no apikey provided, must look in environment or properties for it.
+        this(null);
+    }
+
+    public HoneybadgerReporter(String apiKey){
+        this.apiKey = apiKey;
         this.excludedExceptionClasses = buildExcludedExceptionClasses();
     }
 
@@ -212,7 +219,7 @@ public class HoneybadgerReporter implements NoticeReporter {
     private Request buildRequest(URI honeybadgerUrl, String jsonError) {
         Request request = Request
                .Post(honeybadgerUrl)
-               .addHeader("X-API-Key", apiKey())
+               .addHeader("X-API-Key", getAPIKey())
                .addHeader("Accept", "application/json")
                .version(HttpVersion.HTTP_1_1)
                .bodyString(jsonError, ContentType.APPLICATION_JSON);
@@ -259,14 +266,17 @@ public class HoneybadgerReporter implements NoticeReporter {
     }
 
     /**
-     * Finds the API key, preferring ENV to system properties.
+     * Finds the API key, searching in this order:
+     *   - The apiKey instance variable
+     *   - ENV
+     *   - system properties.
      *
      * @return the API key if found, otherwise null
      */
-    private String apiKey() {
+    private String getAPIKey() {
+      if(apiKey != null) return apiKey;
       String envKey = System.getenv("HONEYBADGER_API_KEY");
       if (envKey != null && !envKey.isEmpty()) return envKey;
-
       return System.getProperty(HONEYBADGER_API_KEY_SYS_PROP_KEY);
     }
 }

--- a/src/main/java/io/honeybadger/reporter/NoticeReporter.java
+++ b/src/main/java/io/honeybadger/reporter/NoticeReporter.java
@@ -15,6 +15,9 @@ public interface NoticeReporter {
     String HONEYBADGER_API_KEY_SYS_PROP_KEY =
             "honeybadger.api_key";
 
+    /** Environment variable identifying Honeybadger API key to use. */
+    String HONEYBADGER_API_KEY = "HONEYBADGER_API_KEY";
+
     /** CSV list of system properties to not include. */
     String HONEYBADGER_EXCLUDED_PROPS_SYS_PROP_KEY =
             "honeybadger.excluded_sys_props";


### PR DESCRIPTION
This simple change allows users to simply pass in their api key into the constructor.

Users might not have access to set environment variables (at the least, it can be inconvenient, especially in production), and passing the apiKey into the constructor is simpler and clearer than setting a system property.  In my case, it's easiest to get my apiKey via my play config, and then I don't have to set it twice. This allows me to call HoneyBadger easily inside of a play app, but outside the context of an http request (in an akka actor).

All the existing functionality should work exactly as-is, and is fully backwards compatible. This includes checking for the ENV variable, and the system property.
