### PR TITLE
Avoid Thread Local Storage in deserialization of Notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,15 +300,15 @@ as a preliminary step; that way you can be (moderately) sure that your pull requ
 1. Fork it.
 2. Create a topic branch `git checkout -b my_branch`
 3. Configure integration tests to use your API keys (see below).
-4. Run unit and integration tests `./gradlew check`
+4. Run unit and integration tests `./mvn verify`
 5. Commit your changes `git commit -am "Boom"`
 6. Push to your branch `git push origin my_branch`
 7. Send a [pull request](https://github.com/honeybadger-java/honeybadger-java/pulls)
 
 ### Testing
 For the purpose of one off testing, you can use the CLI utility. Just execute it using
-```./gradlew run``` and you can enter in your API key and message to be sent to
-Honeybadger.
+```mvn exec:java -Dexec.mainClass="io.honeybadger.reporter.HoneybadgerCLI"``` from the `honeybadger-java`
+subdirectory and you can enter in your API key and message to be sent to Honeybadger.
 
 #### Running the tests
 

--- a/honeybadger-java/src/integration/java/io/honeybadger/reporter/HoneybadgerReporterIT.java
+++ b/honeybadger-java/src/integration/java/io/honeybadger/reporter/HoneybadgerReporterIT.java
@@ -108,7 +108,16 @@ public class HoneybadgerReporterIT {
 //        }
 
         assertEquals(expected.getNotifier(), actual.getNotifier());
-        assertEquals(expected.getServer(), actual.getServer());
+
+        // Because this is not retrieved by the API the V1 check is not a particularly useful
+        // validation. It only verifies that we return the same data that we put in,
+        // but memory and load data is automatically generated at construction time, so
+        // we'd have to store this context before verifying it.
+        //
+        // Accordingly, instead of this, we're doing some more narrow validation
+        //        assertEquals(expected.getServer(), actual.getServer());
+        assertEquals(expected.getServer().getHostname(), actual.getServer().getHostname());
+        assertEquals(expected.getServer().getEnvironmentName(), actual.getServer().getEnvironmentName());
 
         Request expectedRequest = expected.getRequest();
         Request actualRequest = actual.getRequest();

--- a/honeybadger-java/src/main/java/io/honeybadger/loader/HoneybadgerNoticeLoader.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/loader/HoneybadgerNoticeLoader.java
@@ -24,6 +24,11 @@ import java.util.UUID;
  * Utility class used to load a fault's details into a readable object
  * structure.
  *
+ * This class is currently only suitable for consumption by integration tests,
+ * as much of the data in the reporter dto is not returned by the Notice API.
+ * If you have an use case for Notice deserialization, please file an issue
+ * at https://github.com/honeybadger-io/honeybadger-java
+ *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  * @since 1.0.9
  */
@@ -110,7 +115,7 @@ public class HoneybadgerNoticeLoader {
         OBJECT_MAPPER.setInjectableValues(injectableValues);
         injectableValues.addValue("config", config);
 
-        error = OBJECT_MAPPER.readValue(originalJson.asText(), Notice.class);
+        error = OBJECT_MAPPER.readValue(originalJson.toString(), Notice.class);
         return error;
     }
 }

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Backtrace.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Backtrace.java
@@ -1,5 +1,6 @@
 package io.honeybadger.reporter.dto;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.honeybadger.reporter.config.ConfigContext;
 
@@ -16,6 +17,7 @@ public class Backtrace extends ArrayList<BacktraceElement>
         implements Serializable {
     private static final long serialVersionUID = 5788866962863555294L;
 
+    @JacksonInject("config")
     private final ConfigContext config;
 
     /**

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Backtrace.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Backtrace.java
@@ -1,6 +1,7 @@
 package io.honeybadger.reporter.dto;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.honeybadger.reporter.config.ConfigContext;
 
@@ -17,7 +18,6 @@ public class Backtrace extends ArrayList<BacktraceElement>
         implements Serializable {
     private static final long serialVersionUID = 5788866962863555294L;
 
-    @JacksonInject("config")
     private final ConfigContext config;
 
     /**
@@ -34,6 +34,14 @@ public class Backtrace extends ArrayList<BacktraceElement>
         }
 
         addTrace(error);
+    }
+
+    /**
+     * For the benefit of deserialization
+     */
+    @JsonCreator
+    public Backtrace(@JacksonInject("config") final ConfigContext config) {
+        this.config = config;
     }
 
     /**

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/BacktraceElement.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/BacktraceElement.java
@@ -1,7 +1,9 @@
 package io.honeybadger.reporter.dto;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.honeybadger.reporter.config.ConfigContext;
 
 import java.io.Serializable;
@@ -60,8 +62,11 @@ public class BacktraceElement implements Serializable {
     private final String number;
     private final String context;
 
-    public BacktraceElement(final ConfigContext config, final String number, final String file,
-                            final String method) {
+    @JsonCreator
+    public BacktraceElement(@JacksonInject("config") final ConfigContext config,
+                            @JsonProperty("number") final String number,
+                            @JsonProperty("file") final String file,
+                            @JsonProperty("method") final String method) {
         this.config = config;
         this.number = number;
         this.file = file;

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/BacktraceElement.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/BacktraceElement.java
@@ -1,5 +1,6 @@
 package io.honeybadger.reporter.dto;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.honeybadger.reporter.config.ConfigContext;
 
@@ -35,6 +36,7 @@ public class BacktraceElement implements Serializable {
         }
     }
 
+    @JacksonInject("config")
     private final ConfigContext config;
 
     public String getFile() {

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Details.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Details.java
@@ -1,6 +1,7 @@
 package io.honeybadger.reporter.dto;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.honeybadger.reporter.config.ConfigContext;
 import org.slf4j.MDC;
@@ -22,10 +23,10 @@ public class Details extends LinkedHashMap<String, Map<String, String>>
         implements Serializable {
     private static final long serialVersionUID = -6238693264237448645L;
 
-    @JacksonInject("config")
     private final ConfigContext config;
 
-    public Details(final ConfigContext config) {
+    @JsonCreator
+    public Details(@JacksonInject("config") final ConfigContext config) {
         this.config = config;
     }
 

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Details.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Details.java
@@ -1,5 +1,6 @@
 package io.honeybadger.reporter.dto;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.honeybadger.reporter.config.ConfigContext;
 import org.slf4j.MDC;
@@ -21,6 +22,7 @@ public class Details extends LinkedHashMap<String, Map<String, String>>
         implements Serializable {
     private static final long serialVersionUID = -6238693264237448645L;
 
+    @JacksonInject("config")
     private final ConfigContext config;
 
     public Details(final ConfigContext config) {

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Load.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Load.java
@@ -1,6 +1,8 @@
 package io.honeybadger.reporter.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
@@ -32,7 +34,10 @@ public class Load implements Serializable {
         this.fifteen = loadAverages[2];
     }
 
-    public Load(final Number one, final Number five, final Number fifteen) {
+    @JsonCreator
+    public Load(@JsonProperty("one") final Number one,
+                @JsonProperty("five") final Number five,
+                @JsonProperty("fifteen") final Number fifteen) {
         this.one = one;
         this.five = five;
         this.fifteen = fifteen;

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Memory.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Memory.java
@@ -1,5 +1,6 @@
 package io.honeybadger.reporter.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.slf4j.LoggerFactory;
@@ -76,9 +77,17 @@ public class Memory implements Serializable {
 
     @SuppressWarnings("ParameterNumber")
     // No reason to be restrictive for a DTO
-    public Memory(final Number total, final Number free, final Number buffers, final Number cached,
-                  final Number freeTotal, final Number vmFree, final Number vmMax,
-                  final Number vmTotal, final Number vmHeap, final Number vmNonheap) {
+    @JsonCreator
+    public Memory(@JsonProperty("total") final Number total,
+                  @JsonProperty("free") final Number free,
+                  @JsonProperty("buffers") final Number buffers,
+                  @JsonProperty("cached") final Number cached,
+                  @JsonProperty("free_total") final Number freeTotal,
+                  @JsonProperty("vm_free") final Number vmFree,
+                  @JsonProperty("vm_max") final Number vmMax,
+                  @JsonProperty("vm_total") final Number vmTotal,
+                  @JsonProperty("vm_heap") final Number vmHeap,
+                  @JsonProperty("vm_nonheap") final Number vmNonheap) {
         this.total = total;
         this.free = free;
         this.buffers = buffers;

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Notice.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Notice.java
@@ -1,7 +1,10 @@
 package io.honeybadger.reporter.dto;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.honeybadger.reporter.config.ConfigContext;
 
 import java.io.Serializable;
@@ -9,14 +12,16 @@ import java.util.Objects;
 
 /**
  * Class representing an error that is reported to the Honeybadger API.
+ *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  * @since 1.0.9
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties({"environment", "created_at", "message", "token", "fault_id",
+        "application_trace", "backtrace", "deploy", "url"})
 public class Notice implements Serializable {
     private static final long serialVersionUID = 1661111694538362413L;
-
-    @JacksonInject("config")
+    private Long id = null;
     private final ConfigContext config;
 
     private Notifier notifier = new Notifier();
@@ -32,6 +37,18 @@ public class Notice implements Serializable {
         this.server = new ServerDetails(config);
         this.details = new Details(this.config);
         this.details.addDefaultDetails();
+    }
+
+    @JsonCreator
+    public Notice(@JacksonInject("config") final ConfigContext config,
+                  @JsonProperty("id") final Long id,
+                  @JsonProperty("web_environment") final CgiData webEnvironment,
+                  @JsonProperty("request") final Request request) {
+        this.config = config;
+        this.id = id;
+        this.server = new ServerDetails(config);
+        this.request = request;
+        this.request.setCgiData(webEnvironment);
     }
 
     public Notifier getNotifier() {
@@ -95,5 +112,9 @@ public class Notice implements Serializable {
     @Override
     public int hashCode() {
         return Objects.hash(config, notifier, server, details, request, error);
+    }
+
+    public Long getId() {
+        return id;
     }
 }

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Notice.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Notice.java
@@ -1,5 +1,6 @@
 package io.honeybadger.reporter.dto;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.honeybadger.reporter.config.ConfigContext;
 
@@ -15,6 +16,7 @@ import java.util.Objects;
 public class Notice implements Serializable {
     private static final long serialVersionUID = 1661111694538362413L;
 
+    @JacksonInject("config")
     private final ConfigContext config;
 
     private Notifier notifier = new Notifier();

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Params.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Params.java
@@ -1,5 +1,7 @@
 package io.honeybadger.reporter.dto;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.honeybadger.reporter.config.ConfigContext;
 
 import java.io.Serializable;
@@ -21,12 +23,8 @@ public class Params extends LinkedHashMap<String, String>
         this.excludedValues = excludedValues;
     }
 
-    @Deprecated
-    public Params() {
-        ConfigContext config = ConfigContext.THREAD_LOCAL.get();
-        if (config == null) throw new NullPointerException(
-                "Unable to get the expected ConfigContext from ThreadLocal");
-
+    @JsonCreator
+    public Params(final @JacksonInject("config") ConfigContext config) {
         this.excludedValues = config.getExcludedParams();
     }
 

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Request.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Request.java
@@ -1,7 +1,9 @@
 package io.honeybadger.reporter.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -20,11 +22,12 @@ public class Request implements Serializable {
     private final Params params;
     private final Session session;
     @JsonProperty("cgi_data")
-    private final CgiData cgiData;
+    private CgiData cgiData;
 
-    public Request(final Context context, final String url,
-                   final Params params, final Session session,
-                   final CgiData cgiData) {
+    @JsonCreator
+    public Request(@JsonProperty("context")final Context context, @JsonProperty("url") final String url,
+                   @JsonProperty("params") final Params params,  @JsonProperty("session") final Session session,
+                   @JsonProperty("cgi_data") final CgiData cgiData) {
         this.context = context;
         this.url = url;
         this.params = params;
@@ -63,6 +66,10 @@ public class Request implements Serializable {
 
     public CgiData getCgiData() {
         return cgiData;
+    }
+
+    public void setCgiData(final CgiData value) {
+        this.cgiData = value;
     }
 
     public Context getContext() {

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/ServerDetails.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/ServerDetails.java
@@ -1,5 +1,6 @@
 package io.honeybadger.reporter.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -47,8 +48,13 @@ public class ServerDetails implements Serializable {
         this.stats = new Stats();
     }
 
-    public ServerDetails(final String environmentName, final String hostname, final String projectRoot,
-                         final Integer pid, final String time, final Stats stats) {
+    @JsonCreator
+    public ServerDetails(@JsonProperty("environment_name") final String environmentName,
+                         @JsonProperty("hostname") final String hostname,
+                         @JsonProperty("project_root") final String projectRoot,
+                         @JsonProperty("pid") final Integer pid,
+                         @JsonProperty("time") final String time,
+                         @JsonProperty("stats") final Stats stats) {
         this.environmentName = environmentName;
         this.hostname = hostname;
         this.projectRoot = projectRoot;

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Stats.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Stats.java
@@ -1,6 +1,8 @@
 package io.honeybadger.reporter.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -32,7 +34,9 @@ public class Stats implements Serializable {
         this.load = new Load();
     }
 
-    public Stats(final Memory mem, final Load load) {
+    @JsonCreator
+    public Stats(@JsonProperty("mem") final Memory mem,
+                 @JsonProperty("load") final Load load) {
         this.mem = mem;
         this.load = load;
     }


### PR DESCRIPTION
Issue #48 on the honeybadger-io github issues list

- candidate solution for removing thread local hack in
HoneyBadgerNoticeLoader
- Uses a Jackson-specific feature for injecting values.
- passes integration tests locally, but may need to do some additional
work to be sure it works all the way down the object graph
- Probably need to remove a deprecated constructor or two in the DTOs