### PR TITLE
Java 11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,5 +72,16 @@ matrix:
         - DESC="zulu-9 unit tests"
         - CMD="mvn clean test -Dcheckstyle.skip=true"
         - LANG=en_US.utf8
+    - jdk: oraclejdk10
+      env:
+        - DESC="oraclejdk10 unit tests"
+        - CMD="mvn clean test -Dcheckstyle.skip=true"
+        - LANG=en_US.utf8
+    - jdk: oraclejdk11
+      env:
+        - DESC="oraclejdk11 unit tests"
+        - CMD="mvn clean test -Dcheckstyle.skip=true"
+        - LANG=en_US.utf8
+
 
 script: echo ${CMD}; ${CMD}

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,10 @@ matrix:
         - DESC="openjdk11 unit tests"
         - CMD="mvn clean test -Dcheckstyle.skip=true"
         - LANG=en_US.utf8
-
+    - jdk: openjdk12
+      env:
+        - DESC="openjdk12 unit tests"
+        - CMD="mvn clean test -Dcheckstyle.skip=true"
+        - LANG=en_US.utf8
 
 script: echo ${CMD}; ${CMD}

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,14 +72,14 @@ matrix:
         - DESC="zulu-9 unit tests"
         - CMD="mvn clean test -Dcheckstyle.skip=true"
         - LANG=en_US.utf8
-    - jdk: oraclejdk10
+    - jdk: openjdk10
       env:
-        - DESC="oraclejdk10 unit tests"
+        - DESC="openjdk10 unit tests"
         - CMD="mvn clean test -Dcheckstyle.skip=true"
         - LANG=en_US.utf8
-    - jdk: oraclejdk11
+    - jdk: openjdk11
       env:
-        - DESC="oraclejdk11 unit tests"
+        - DESC="openjdk11 unit tests"
         - CMD="mvn clean test -Dcheckstyle.skip=true"
         - LANG=en_US.utf8
 

--- a/README.md
+++ b/README.md
@@ -8,18 +8,24 @@ When an uncaught exception occurs, Honeybadger will POST the relevant data to th
 
 ## Supported JVM versions
 
-| JVM               | Supported Version |
+| JVM               | Supported Version | 
 | ----------------- | ----------------- |
-| Oracle (Java SE)  | 1.7, 1.8          |
-| OpenJDK JDK/JRE   | 1.7, 1.8          |
+| Oracle (Java SE)  | 1.7, 1.8, 9, [10, 11, 12]* |
+| OpenJDK JDK/JRE   | 1.7, 1.8, 9, 10, 11, 12    |
+
+*Limitations*:
+We don't currently test on Oracle's commercially licensed VMs, due to new
+licensing rules. Accordingly, Oracle JDK after version 9 is supported on a best-effort basis only.
+If you discover a defect specific to their commercially-licensed VM,
+please [submit an issue](https://github.com/honeybadger-io/honeybadger-java/issues/new).
 
 ## Supported web frameworks
 
-| Framework         | Version |
-| ----------------- | ------- |
-| Servlet API       | 3.1.0   |
-| Play Framework    | 2.4.2   |
-| Spring Framework  | 4.2.2   |
+| Framework         | Version | Notes |
+| ----------------- | ------- | ----- |
+| Servlet API       | 4.0.1   | |
+| Play Framework    | 2.7.2   | We still call one deprecated API. See [Issue #110](https://github.com/honeybadger-io/honeybadger-java/issues/110)|
+| Spring Framework  | 5.1.7   | |
 
 The Play Framework Spring are supported natively (install/configure the library and your done). 
 For the Servlet API, you  will need to configure a [servlet filter](https://github.com/honeybadger-io/honeybadger-java/tree/master/honeybadger-java/src/main/java/io/honeybadger/reporter/servlet/HoneybadgerFilter.java) 

--- a/honeybadger-java/src/main/java/io/honeybadger/loader/HoneybadgerNoticeLoader.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/loader/HoneybadgerNoticeLoader.java
@@ -1,10 +1,10 @@
 package io.honeybadger.loader;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.honeybadger.reporter.config.ConfigContext;
 import io.honeybadger.reporter.dto.Notice;
@@ -38,8 +38,9 @@ public class HoneybadgerNoticeLoader {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-                    .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                    .configure(SerializationFeature.WRITE_NULL_MAP_VALUES, false);
+    .setDefaultPropertyInclusion(
+            JsonInclude.Value.construct(Include.ALWAYS, Include.NON_NULL))
+                    .setSerializationInclusion(Include.NON_NULL);
 
     private ConfigContext config;
 

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/NoticeReportResult.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/NoticeReportResult.java
@@ -37,7 +37,7 @@ public class NoticeReportResult {
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (o == null || !(o instanceof NoticeReportResult)) return false;
         NoticeReportResult that = (NoticeReportResult) o;
         return Objects.equals(id, that.id) &&
                 Objects.equals(notice, that.notice) &&

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/config/BaseChainedConfigContext.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/config/BaseChainedConfigContext.java
@@ -254,7 +254,7 @@ public abstract class BaseChainedConfigContext implements ConfigContext {
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (o == null || !(o instanceof BaseChainedConfigContext)) return false;
         BaseChainedConfigContext that = (BaseChainedConfigContext) o;
         return Objects.equals(environment, that.environment) &&
                 Objects.equals(honeybadgerUrl, that.honeybadgerUrl) &&

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/BacktraceElement.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/BacktraceElement.java
@@ -107,7 +107,7 @@ public class BacktraceElement implements Serializable {
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (o == null || !(o instanceof BacktraceElement)) return false;
         BacktraceElement that = (BacktraceElement) o;
         return Objects.equals(config, that.config) &&
                 Objects.equals(file, that.file) &&

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Cause.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Cause.java
@@ -31,7 +31,7 @@ public class Cause implements Serializable {
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (o == null || !(o instanceof Cause)) return false;
         Cause cause = (Cause) o;
         return Objects.equals(getClassName(), cause.getClassName()) &&
                 Objects.equals(getMessage(), cause.getMessage()) &&

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Causes.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Causes.java
@@ -12,7 +12,7 @@ import java.util.LinkedList;
  * @since 1.0.9
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@SuppressWarnings("JdkObsolete")
+@SuppressWarnings("JdkObsolete") // Reason: subtle interface change if we change LinkedList to ArrayList
 public class Causes extends LinkedList<Cause> implements Serializable {
     private static final long serialVersionUID = -5359764114506595006L;
 
@@ -34,15 +34,15 @@ public class Causes extends LinkedList<Cause> implements Serializable {
         int iterations = 0;
 
         do {
-            // If we are in a simple circular reference, exit
-            if (lastCause != null && lastCause.equals(nextCause)) break;
-
             addFirst(new Cause(config, nextCause));
-
-            // Since we could have multi-class circular ref we just check
-            // for too big of a cause trace
-            if (++iterations > MAX_CAUSES) break;
+            ++iterations;
             lastCause = nextCause;
-        } while (null != (nextCause = nextCause.getCause())); //checkstyle ignore
+            nextCause = nextCause.getCause();
+        } while (null != nextCause &&
+                // If we are in a simple circular reference, stop.
+                !lastCause.equals(nextCause) &&
+                // Since we could have multi-class circular ref we just check
+                // for too big of a cause trace
+                iterations <= MAX_CAUSES);
     }
 }

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Load.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Load.java
@@ -103,7 +103,7 @@ public class Load implements Serializable {
             return true;
         }
 
-        if (o == null || getClass() != o.getClass()) {
+        if (o == null || !(o instanceof Load)) {
             return false;
         }
 

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Memory.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Memory.java
@@ -166,7 +166,7 @@ public class Memory implements Serializable {
             return true;
         }
 
-        if (o == null || getClass() != o.getClass()) {
+        if (o == null || !(o instanceof Memory)) {
             return false;
         }
 

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Notice.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Notice.java
@@ -99,7 +99,7 @@ public class Notice implements Serializable {
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (o == null || !(o instanceof Notice)) return false;
         Notice notice = (Notice) o;
         return Objects.equals(config, notice.config) &&
                 Objects.equals(notifier, notice.notifier) &&

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/NoticeDetails.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/NoticeDetails.java
@@ -52,7 +52,7 @@ public class NoticeDetails implements Serializable {
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (o == null || !(o instanceof NoticeDetails)) return false;
         NoticeDetails that = (NoticeDetails) o;
         return Objects.equals(getClassName(), that.getClassName()) &&
                 Objects.equals(getMessage(), that.getMessage()) &&

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Notifier.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Notifier.java
@@ -68,7 +68,7 @@ public class Notifier implements Serializable {
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (o == null || !(o instanceof Notifier)) return false;
         Notifier notifier = (Notifier) o;
         return Objects.equals(name, notifier.name) &&
                 Objects.equals(url, notifier.url) &&

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Request.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Request.java
@@ -38,7 +38,7 @@ public class Request implements Serializable {
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (o == null || !(o instanceof Request)) return false;
         Request request = (Request) o;
         return Objects.equals(getContext(), request.getContext()) &&
                 Objects.equals(getUrl(), request.getUrl()) &&

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/ServerDetails.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/ServerDetails.java
@@ -96,7 +96,7 @@ public class ServerDetails implements Serializable {
      */
     protected static String projectRoot() {
         try {
-            return (new File(".")).getCanonicalPath();
+            return new File(".").getCanonicalPath();
         } catch (IOException e) {
             logger.error("Can't get runtime root path", e);
             return "unknown";
@@ -140,7 +140,7 @@ public class ServerDetails implements Serializable {
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (o == null || !(o instanceof ServerDetails)) return false;
         ServerDetails that = (ServerDetails) o;
         return Objects.equals(getEnvironmentName(), that.getEnvironmentName()) &&
                 Objects.equals(getHostname(), that.getHostname()) &&

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Stats.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/dto/Stats.java
@@ -44,7 +44,7 @@ public class Stats implements Serializable {
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (o == null || !(o instanceof Stats)) return false;
 
         Stats stats = (Stats) o;
 

--- a/honeybadger-java/src/test/java/io/honeybadger/reporter/FeedbackFormTest.java
+++ b/honeybadger-java/src/test/java/io/honeybadger/reporter/FeedbackFormTest.java
@@ -13,7 +13,7 @@ public class FeedbackFormTest {
     @Test
     public void feedbackFormRendersTemplate() throws Exception {
         StringWriter writer = new StringWriter();
-        String id = (new UUID(12L, 36L)).toString();
+        String id = new UUID(12L, 36L).toString();
         StandardConfigContext config = new StandardConfigContext();
         config.setFeedbackFormPath("templates/feedback-form.mustache");
         FeedbackForm instance = new FeedbackForm(config);

--- a/honeybadger-java/src/test/java/io/honeybadger/reporter/dto/NoticeTest.java
+++ b/honeybadger-java/src/test/java/io/honeybadger/reporter/dto/NoticeTest.java
@@ -1,9 +1,7 @@
 package io.honeybadger.reporter.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import com.github.fge.jsonschema.core.report.ProcessingMessage;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
@@ -25,6 +23,8 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Map;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include;
+import static com.fasterxml.jackson.annotation.JsonInclude.Value;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -45,10 +45,9 @@ public class NoticeTest {
             "https://gist.githubusercontent.com/JasonTrue/80e28e9debe4a9a94164c85bf5ec5f85/raw/fbd90c052133ac911606743547583797a5d1b8f3/notices.json";
             // originally: "https://gist.githubusercontent.com/joshuap/94901ba378fd09a783be/raw/b632ff0a6b1ec82ced73735a321f1e44e94669d2/notices.json";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-                    .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                    .configure(SerializationFeature.WRITE_NULL_MAP_VALUES, false);
-    // This should be mapper.setDefaultPropertyInclusion(
-    //   JsonInclude.Value.construct(Include.ALWAYS, Include.NON_NULL)) in jackson 2.9.
+                    .setDefaultPropertyInclusion(
+                            Value.construct(Include.ALWAYS, Include.NON_NULL))
+                    .setSerializationInclusion(Include.NON_NULL);
 
     private final JsonNode schema;
 
@@ -124,8 +123,7 @@ public class NoticeTest {
     private void validateReportedErrorJson(Notice error)
             throws ProcessingException, IOException {
         String jsonText = OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(error);
-        JsonSchemaFactory factory = JsonSchemaFactory.byDefault();
-        JsonValidator validator = factory.byDefault().getValidator();
+        JsonValidator validator = JsonSchemaFactory.byDefault().getValidator();
 
         JsonNode jsonNode = OBJECT_MAPPER.readTree(jsonText);
         ProcessingReport report = validator.validate(schema, jsonNode);

--- a/pom.xml
+++ b/pom.xml
@@ -74,13 +74,15 @@
         <maven.integration.test.skip>false</maven.integration.test.skip>
         <java.min.src.version>1.8</java.min.src.version>
         <java.min.target.version>1.8</java.min.target.version>
-        <maven.min.version>3.0</maven.min.version>
+        <maven.min.version>3.0.5</maven.min.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire.forkCount>1</surefire.forkCount>
         <surefire.useSystemClassLoader>true</surefire.useSystemClassLoader>
         <failsafe.forkCount>1</failsafe.forkCount>
         <failsafe.useSystemClassLoader>true</failsafe.useSystemClassLoader>
+        <!-- Only for Java 8 support, per https://errorprone.info/docs/installation -->
+        <javac.version>9+181-r4173-1</javac.version>
 
         <!-- Dependency versions -->
         <dependency.apache-commons.version>3.9</dependency.apache-commons.version>
@@ -96,7 +98,7 @@
         <!-- Test Dependency Versions -->
         <dependency.junit.version>4.12</dependency.junit.version>
         <dependency.guava.version>27.1-jre</dependency.guava.version>
-        <dependency.mockito.version>2.28.1</dependency.mockito.version>
+        <dependency.mockito.version>2.28.2</dependency.mockito.version>
         <dependency.logback.version>1.2.3</dependency.logback.version>
         <dependency.json-schema-validator>2.2.6</dependency.json-schema-validator>
 
@@ -106,12 +108,12 @@
         <maven-build-helper-plugin>1.10</maven-build-helper-plugin>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
-        <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
-        <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
+        <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
+        <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
         <maven-extra-enforcer-rules.version>1.2</maven-extra-enforcer-rules.version>
-        <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
+        <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
-        <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
+        <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
         <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
         <maven-jarsigner-plugin.version>3.0.0</maven-jarsigner-plugin.version>
         <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
@@ -119,12 +121,12 @@
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
         <maven-shade-plugin.version>3.2.1</maven-shade-plugin.version>
         <maven-cargo-plugin.version>1.6.7</maven-cargo-plugin.version>
         <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
         <!-- Maven plugin dependency versions -->
-        <maven-plexus-compiler-javac-errorprone.version>2.8.5</maven-plexus-compiler-javac-errorprone.version>
+<!--        <maven-plexus-compiler-javac-errorprone.version>2.8.5</maven-plexus-compiler-javac-errorprone.version>-->
         <maven-error-prone-core.version>2.3.3</maven-error-prone-core.version>
         <maven-directory-maven-plugin.version>0.3.1</maven-directory-maven-plugin.version>
         <maven-build-helper-maven-plugin.version>3.0.0</maven-build-helper-maven-plugin.version>
@@ -233,23 +235,24 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <compilerId>javac-with-errorprone</compilerId>
-                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                    <fork>true</fork>
                     <source>${java.min.src.version}</source>
                     <target>${java.min.target.version}</target>
-                    <showWarnings>true</showWarnings>
                     <compilerArgs>
+                        <arg>-XDcompilePolicy=simple</arg>
+                        <arg>-Xplugin:ErrorProne</arg>
                         <arg>-Xlint:all</arg>
                     </compilerArgs>
+                    <showWarnings>true</showWarnings>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.errorprone</groupId>
+                            <artifactId>error_prone_core</artifactId>
+                            <version>${maven-error-prone-core.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
                 <dependencies>
-                    <dependency>
-                        <groupId>org.codehaus.plexus</groupId>
-                        <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                        <version>${maven-plexus-compiler-javac-errorprone.version}</version>
-                    </dependency>
-                    <!-- override plexus-compiler-javac-errorprone's dependency on
-                         Error Prone with the latest version -->
                     <dependency>
                         <groupId>com.google.errorprone</groupId>
                         <artifactId>error_prone_core</artifactId>
@@ -542,6 +545,28 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
+            <!-- See https://errorprone.info/docs/installation -->
+            <id>jdk8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <fork>true</fork>
+                            <compilerArgs combine.children="append">
+                                <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</arg>
+                            </compilerArgs>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,6 @@
         <maven-cargo-plugin.version>1.6.7</maven-cargo-plugin.version>
         <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
         <!-- Maven plugin dependency versions -->
-<!--        <maven-plexus-compiler-javac-errorprone.version>2.8.5</maven-plexus-compiler-javac-errorprone.version>-->
         <maven-error-prone-core.version>2.3.3</maven-error-prone-core.version>
         <maven-directory-maven-plugin.version>0.3.1</maven-directory-maven-plugin.version>
         <maven-build-helper-maven-plugin.version>3.0.0</maven-build-helper-maven-plugin.version>
@@ -565,6 +564,29 @@
                             <fork>true</fork>
                             <compilerArgs combine.children="append">
                                 <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- Current versions of Error-Prone fail on JDK 12, so we disable it
+                 when building with JDK 12 -->
+            <id>jdk12</id>
+            <activation>
+                <jdk>12</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <fork>true</fork>
+                            <compilerArgs>
+                                <arg>-XDcompilePolicy=simple</arg>
+                                <arg>-Xlint:all</arg>
                             </compilerArgs>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
- Adds JDK 10/11/12 to configuration matrix in travis
- Also makes sure that those tests pass (eliminates an error that occurred with Java 11)
- Updates documentation to reflect supported versions
- Updates Maven minimum version to 3.0.5 (Mainly to support more recent versions of maven plugins)
- Follow some Google advice for .equals implementations (Error-Prone)
- Simplifies error reporting loop for readability
- Additionally tested using crywolf with Java 12 (separate pull request to update Crywolf to latest Spring Boot version coming shortly).