### PR TITLE
Rethrow excluded exceptions when handling with Spring

### DIFF
--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/spring/HoneybadgerSpringExceptionHandler.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/spring/HoneybadgerSpringExceptionHandler.java
@@ -77,6 +77,13 @@ public class HoneybadgerSpringExceptionHandler {
             throw exception;
         }
 
+        // Rethrow any exceptions that are excluded. Important to differentiate between
+        // this and NoticeReporter.reportError returning null which could indicate an
+        // error communicating with the Honeybadger API.
+        if (context.getExcludedClasses().contains(exception.getClass().getName())) {
+            throw exception;
+        }
+
         NoticeReportResult result = getReporter().reportError(exception, request);
 
         if (logger.isErrorEnabled()) {

--- a/honeybadger-java/src/test/java/io/honeybadger/reporter/spring/HoneybadgerSpringExceptionHandlerTest.java
+++ b/honeybadger-java/src/test/java/io/honeybadger/reporter/spring/HoneybadgerSpringExceptionHandlerTest.java
@@ -1,0 +1,29 @@
+package io.honeybadger.reporter.spring;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.collect.ImmutableSet;
+import io.honeybadger.reporter.UnitTestExpectedException;
+import io.honeybadger.reporter.config.SpringConfigContext;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.Test;
+
+/**
+ * Tests {@link HoneybadgerSpringExceptionHandler}.
+ */
+public class HoneybadgerSpringExceptionHandlerTest {
+  private final SpringConfigContext context = new SpringConfigContext(null);
+  private final HttpServletRequest request = mock(HttpServletRequest.class);
+
+  @Test
+  public void handlerRethrowsExcludedExceptionsTest() {
+    context.setApiKey("api-key");
+    context.setExcludedClasses(ImmutableSet.of(
+      "io.honeybadger.reporter.UnitTestExpectedException"));
+    HoneybadgerSpringExceptionHandler handler = new HoneybadgerSpringExceptionHandler(context);
+
+    assertThrows(UnitTestExpectedException.class,
+      () -> handler.defaultErrorHandler(request, new UnitTestExpectedException()));
+  }
+}


### PR DESCRIPTION
https://github.com/honeybadger-io/honeybadger-java/issues/241

Fix issue where excluded exceptions generate NPEs in the Spring exception handler. Rethrow the exception so Spring can process it with another handler.

Added a test that verifies the issue but some additional refactoring needed to make it easy to get a mock NoticeReporter into the handler to write a positive test.