### PR TITLE
Add socket and connection timeouts

### DIFF
--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/HoneybadgerReporter.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/HoneybadgerReporter.java
@@ -385,6 +385,14 @@ public class HoneybadgerReporter implements NoticeReporter {
             request.viaProxy(proxy);
         }
 
+        if (getConfig().getSocketTimeout() != null) {
+            request.socketTimeout(getConfig().getSocketTimeout());
+        }
+
+        if (getConfig().getConnectTimeout() != null) {
+            request.connectTimeout(getConfig().getConnectTimeout());
+        }
+
         return request;
     }
 

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/config/BaseChainedConfigContext.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/config/BaseChainedConfigContext.java
@@ -36,6 +36,8 @@ public abstract class BaseChainedConfigContext implements ConfigContext {
     private String httpProxyHost;
     private Integer httpProxyPort;
     private Integer maximumErrorReportingRetries;
+    private Integer socketTimeout;
+    private Integer connectTimeout;
 
     /**
      * Constructor that prepopulates configuration context with the default
@@ -180,6 +182,25 @@ public abstract class BaseChainedConfigContext implements ConfigContext {
         return this;
     }
 
+    @Override
+    public Integer getSocketTimeout() {
+        return socketTimeout;
+    }
+
+    public BaseChainedConfigContext setSocketTimeout(final Integer socketTimeout) {
+        this.socketTimeout = socketTimeout;
+        return this;
+    }
+
+    @Override
+    public Integer getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public BaseChainedConfigContext setConnectTimeout(final Integer connectTimeout) {
+        this.connectTimeout = connectTimeout;
+        return this;
+    }
 
     /**
      * Overwrites the configuration values with the values of the passed context
@@ -238,6 +259,14 @@ public abstract class BaseChainedConfigContext implements ConfigContext {
         if (context.getMaximumErrorReportingRetries() != null) {
             this.maximumErrorReportingRetries = context.getMaximumErrorReportingRetries();
         }
+
+        if (context.getSocketTimeout() != null) {
+            this.socketTimeout = context.getSocketTimeout();
+        }
+
+        if (context.getConnectTimeout() != null) {
+            this.connectTimeout = context.getConnectTimeout();
+        }
     }
 
     @SuppressWarnings("HiddenField")
@@ -268,7 +297,9 @@ public abstract class BaseChainedConfigContext implements ConfigContext {
                 Objects.equals(feedbackFormPath, that.feedbackFormPath) &&
                 Objects.equals(httpProxyHost, that.httpProxyHost) &&
                 Objects.equals(httpProxyPort, that.httpProxyPort) &&
-                Objects.equals(maximumErrorReportingRetries, that.maximumErrorReportingRetries);
+                Objects.equals(maximumErrorReportingRetries, that.maximumErrorReportingRetries) &&
+                Objects.equals(socketTimeout, that.socketTimeout) &&
+                Objects.equals(connectTimeout, that.connectTimeout);
     }
 
     @Override
@@ -287,6 +318,8 @@ public abstract class BaseChainedConfigContext implements ConfigContext {
                 ", httpProxyHost='" + httpProxyHost + '\'' +
                 ", httpProxyPort=" + httpProxyPort +
                 ", maximumErrorReportingRetries=" + maximumErrorReportingRetries +
+                ", socketTimeout=" + socketTimeout +
+                ", connectTimeout=" + connectTimeout +
                 '}';
     }
 
@@ -294,7 +327,8 @@ public abstract class BaseChainedConfigContext implements ConfigContext {
     public int hashCode() {
         return Objects.hash(environment, honeybadgerUrl, apiKey, excludedSysProps, excludedParams,
                 excludedClasses, applicationPackage, honeybadgerReadApiKey, feedbackFormDisplayed,
-                feedbackFormPath, httpProxyHost, httpProxyPort, maximumErrorReportingRetries);
+                feedbackFormPath, httpProxyHost, httpProxyPort, maximumErrorReportingRetries,
+                socketTimeout, connectTimeout);
     }
 
     protected Boolean getFeedbackFormDisplayed() {

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/config/ConfigContext.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/config/ConfigContext.java
@@ -50,4 +50,10 @@ public interface ConfigContext {
     /** @return Optional configuration parameter to adjust number of attempts to retry sending an error
      * report in the event of a network timeout or other transmission exception. Defaults to 3. */
     Integer getMaximumErrorReportingRetries();
+
+    /** @return Timeout for socket connection within HTTP client */
+    Integer getSocketTimeout();
+
+    /** @return Timeout for initial connect within HTTP client */
+    Integer getConnectTimeout();
 }

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/config/DefaultsConfigContext.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/config/DefaultsConfigContext.java
@@ -112,4 +112,14 @@ public class DefaultsConfigContext implements ConfigContext {
     public Integer getMaximumErrorReportingRetries() {
         return DEFAULT_MAXIMUM_ERROR_REPORTING_RETRIES;
     }
+
+    @Override
+    public Integer getSocketTimeout() {
+        return null;
+    }
+
+    @Override
+    public Integer getConnectTimeout() {
+        return null;
+    }
 }


### PR DESCRIPTION
__Problem__

Recently we've been experiencing issues with sockets staying alive forever within our AWS environment. This leads to threads stuck with no way to close the socket. Ideally these would hit a timeout when making the request so the thread can be recouped.

<details>
    <summary>Example StackTrace</summary>

```
"ThreadName" #154 daemon prio=5 os_prio=0 cpu=2580079.10ms elapsed=1471620.48s tid=0x00007fc828236000 nid=0xe8 runnable  [0x00007fc7bd0de000]
   java.lang.Thread.State: RUNNABLE
        at java.net.SocketInputStream.socketRead0(java.base@11/Native Method)
        at java.net.SocketInputStream.socketRead(java.base@11/SocketInputStream.java:115)
        at java.net.SocketInputStream.read(java.base@11/SocketInputStream.java:168)
        at java.net.SocketInputStream.read(java.base@11/SocketInputStream.java:140)
        at sun.security.ssl.SSLSocketInputRecord.read(java.base@11/SSLSocketInputRecord.java:448)
        at sun.security.ssl.SSLSocketInputRecord.bytesInCompletePacket(java.base@11/SSLSocketInputRecord.java:68)
        at sun.security.ssl.SSLSocketImpl.readApplicationRecord(java.base@11/SSLSocketImpl.java:1104)
        at sun.security.ssl.SSLSocketImpl$AppInputStream.read(java.base@11/SSLSocketImpl.java:823)
        - locked <0x0000000655300d80> (a sun.security.ssl.SSLSocketImpl$AppInputStream)
        at org.apache.http.impl.io.SessionInputBufferImpl.streamRead(SessionInputBufferImpl.java:137)
        at org.apache.http.impl.io.SessionInputBufferImpl.fillBuffer(SessionInputBufferImpl.java:153)
        at org.apache.http.impl.io.SessionInputBufferImpl.readLine(SessionInputBufferImpl.java:280)
        at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:138)
        at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:56)
        at org.apache.http.impl.io.AbstractMessageParser.parse(AbstractMessageParser.java:259)
        at org.apache.http.impl.DefaultBHttpClientConnection.receiveResponseHeader(DefaultBHttpClientConnection.java:163)
        at org.apache.http.impl.conn.CPoolProxy.receiveResponseHeader(CPoolProxy.java:157)
        at org.apache.http.protocol.HttpRequestExecutor.doReceiveResponse(HttpRequestExecutor.java:273)
        at org.apache.http.protocol.HttpRequestExecutor.execute(HttpRequestExecutor.java:125)
        at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:272)
        at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186)
        at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:89)
        at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110)
        at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:56)
        at org.apache.http.client.fluent.Request.internalExecute(Request.java:173)
        at org.apache.http.client.fluent.Request.execute(Request.java:177)
        at io.honeybadger.reporter.HoneybadgerReporter.sendToHoneybadger(HoneybadgerReporter.java:360)
        at io.honeybadger.reporter.HoneybadgerReporter.submitError(HoneybadgerReporter.java:285)
        at io.honeybadger.reporter.HoneybadgerReporter.reportError(HoneybadgerReporter.java:177)
        at io.honeybadger.reporter.HoneybadgerReporter.reportError(HoneybadgerReporter.java:104)
        ...
        at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11/ThreadPoolExecutor.java:1128)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11/ThreadPoolExecutor.java:628)
        at java.lang.Thread.run(java.base@11/Thread.java:834)
```
</details>

__Solution__

HTTP Fluent allows setting a socket timeout and connection timeout value, so add configuration for that at all levels and then set it on all requests.

__Caveats__

I didn't want to set a default that wasn't defaulting to the current behavior since it could affect some expectation folks have, but ideally we'd have a timeout of, at max, 60 seconds, I would assume. Considering HBs normal response time seems to be well below that, I don't think that would be a concern at all.