### PR TITLE
fix(reported-message): always pass reported message

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -45,4 +45,5 @@
        - System properties are now sorted.
        - API for manually building request objects improved.
 2.1.1  - Added support for custom fingerprint.
-2.1.2  - Automated releases with Github Actions
+2.1.2  - Automated releases with Github Actions.
+       - Fixed bug reported message is ignored.

--- a/honeybadger-java/src/main/java/io/honeybadger/reporter/HoneybadgerReporter.java
+++ b/honeybadger-java/src/main/java/io/honeybadger/reporter/HoneybadgerReporter.java
@@ -262,20 +262,16 @@ public class HoneybadgerReporter implements NoticeReporter {
 
         final Notice notice = new Notice(getConfig());
 
-        if (request != null) {
-            final String reportedMessage;
-            if (message != null && !message.isEmpty()) {
-                reportedMessage = message;
-            } else {
-                reportedMessage = parseMessage(error);
-            }
-
-            NoticeDetails noticeDetails = new NoticeDetails(
-                    getConfig(), error, tags, reportedMessage, fingerprint);
-            notice.setRequest(request).setError(noticeDetails);
+        final String reportedMessage;
+        if (message != null && !message.isEmpty()) {
+            reportedMessage = message;
         } else {
-            NoticeDetails noticeDetails = new NoticeDetails(getConfig(), error, tags, null, fingerprint);
-            notice.setError(noticeDetails);
+            reportedMessage = parseMessage(error);
+        }
+        NoticeDetails noticeDetails = new NoticeDetails(getConfig(), error, tags, reportedMessage, fingerprint);
+        notice.setError(noticeDetails);
+        if (request != null) {
+            notice.setRequest(request);
         }
 
         /* We may need to retry sending the JSON, so we temporarily keep it as a string.

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <dependency.servlet-api.version>4.0.1</dependency.servlet-api.version>
         <dependency.play.version>2.8.19</dependency.play.version>
         <dependency.spring.version>5.3.23</dependency.spring.version>
-        <dependency.jackson.version>2.14.1</dependency.jackson.version>
+        <dependency.jackson.version>2.14.2</dependency.jackson.version>
         <dependency.fluent-hc.version>4.5.14</dependency.fluent-hc.version>
         <dependency.jcabi-manifests.version>1.2.1</dependency.jcabi-manifests.version>
         <dependency.mustache.version>0.9.10</dependency.mustache.version>


### PR DESCRIPTION
Fixes bug introduced [here](https://github.com/honeybadger-io/honeybadger-java/pull/433#issuecomment-1425348952).

Additionally, I noticed that if `request == null`, `message` was ignored and `error.getMessage()` would have been used instead of `parseMessage(error)`. I fixed that as well.